### PR TITLE
Add toLower() function

### DIFF
--- a/spec/string_spec.js
+++ b/spec/string_spec.js
@@ -30,4 +30,10 @@ describe('toLower()', function() {
     it('should return a string', function() {
         expect('example string'.toLower()).toEqual(jasmine.any(String));
     });
+
+    it('shoudl return a lower case of the calling string', function() {
+        expect('LOWER CASE'.toLower()).toBe('lower case');
+        expect('PascalCaseD'.toLower()).toBe('pascalcased');
+        expect('MiXeDcAsE'.toLower()).toBe('mixedcase');
+    });
 });

--- a/spec/string_spec.js
+++ b/spec/string_spec.js
@@ -25,3 +25,9 @@ describe('toUpper()', function() {
         expect('MiXeD cAsE'.toUpper()).toBe('MIXED CASE');
     });
 });
+
+describe('toLower()', function() {
+    it('should return a string', function() {
+        expect('example string'.toLower()).toEqual(jasmine.any(String));
+    });
+});

--- a/src/String.js
+++ b/src/String.js
@@ -26,3 +26,7 @@ String.prototype.toUpper = function() {
         return String.fromCharCode(string.charCodeAt(position)-32);
     });
 };
+
+String.prototype.toLower = function() {
+    return "";
+};

--- a/src/String.js
+++ b/src/String.js
@@ -28,5 +28,8 @@ String.prototype.toUpper = function() {
 };
 
 String.prototype.toLower = function() {
-    return "";
+    // the 'this' keyword represents the string calling the function
+    return this.replace(/[A-Z]/g, function(item, position, string) {
+        return String.fromCharCode(string.charCodeAt(position)+32);
+    });
 };


### PR DESCRIPTION
## What does this PR do?

Adds the `toLower()` function to String prototype object. `toLower()` makes use of regular expression to convert the alphabetical characters in its calling string to lowercase.
## Action Points
- Add test to check the return type of `toLower()`
- Add test to check if `toLower()` returns lowercase string.
- Implement `toLower()` to pass the tests above.
