### PR TITLE
Add wordCount() function

### DIFF
--- a/spec/string_spec.js
+++ b/spec/string_spec.js
@@ -91,4 +91,13 @@ describe('wordCount()', function(){
     it('should always return type Number', function(){
         expect('this string'.wordCount()).toEqual(jasmine.any(Number));
     });
+
+    it('should return number of words in a string', function() {
+        expect('this is a string of words'.wordCount()).toBe(6);
+        expect('My name is Ore-ofe'.wordCount()).toBe(4);
+    });
+
+    it('should return 0 if string contains no word', function() {
+        expect(',./;[]=-'.wordCount()).toBe(0);
+    });
 });

--- a/spec/string_spec.js
+++ b/spec/string_spec.js
@@ -84,5 +84,11 @@ describe('words()', function() {
 
     it('should return empty array if no words are found', function() {
         expect(',./;[]=-'.words()).toEqual([]);
-    })
+    });
+});
+
+describe('wordCount()', function(){
+    it('should always return type Number', function(){
+        expect('this string'.wordCount()).toEqual(jasmine.any(Number));
+    });
 });

--- a/src/String.js
+++ b/src/String.js
@@ -88,3 +88,16 @@ String.prototype.words = function() {
     // in the string
     return [];
 };
+
+/**
+ * Word Count
+ * 
+ * wordCount returns the number of words in the string
+ * 
+ * @param {void}
+ * @return {Number} returns the number of words in the calling
+ * string
+ */
+String.prototype.wordCount = function() {
+    return 1;
+};

--- a/src/String.js
+++ b/src/String.js
@@ -99,5 +99,5 @@ String.prototype.words = function() {
  * string
  */
 String.prototype.wordCount = function() {
-    return 1;
+    return this.words().length;
 };


### PR DESCRIPTION
## What does this PR do?

Adds `wordCount()` to the String prototype object. It uses the `words()` function previously defined to get a list of word and then find their length.
## Action Points
- Add test to check `wordCount()` return type.
- Add test to check if `wordCount()` returns the write number of words.
- Add tests to check if `wordCount()` returns 0 if no words are present.
- Implement `wordCount()` to pass the the tests above.
