### PR TITLE
Add fromCurrency() function

### DIFF
--- a/spec/string_spec.js
+++ b/spec/string_spec.js
@@ -116,3 +116,9 @@ describe('toCurrency()', function() {
         expect('1234.123'.toCurrency()).toBe('1,234.12');
     });
 });
+
+describe('fromCurrency()', function() {
+    it('should return a number', function() {
+        expect('111,111.00'.fromCurrency()).toEqual(jasmine.any(Number));
+    });
+});

--- a/spec/string_spec.js
+++ b/spec/string_spec.js
@@ -121,4 +121,8 @@ describe('fromCurrency()', function() {
     it('should return a number', function() {
         expect('111,111.00'.fromCurrency()).toEqual(jasmine.any(Number));
     });
+
+    it('should return number of its calling string', function() {
+        expect('3,123,456.78'.fromCurrency()).toBe(3123456.78);
+    });
 });

--- a/src/String.js
+++ b/src/String.js
@@ -146,5 +146,5 @@ String.prototype.toCurrency = function() {
  * @return {Number} 
  */
 String.prototype.fromCurrency = function() {
-    return 0;
+    return Number(this.replace(/,/g, ''));
 };

--- a/src/String.js
+++ b/src/String.js
@@ -135,3 +135,16 @@ String.prototype.toCurrency = function() {
 
     return result; 
 };
+
+/**
+ * From Currency
+ * 
+ * fromCurrency converts from currency formatted string to a
+ * number
+ * 
+ * @param {void}
+ * @return {Number} 
+ */
+String.prototype.fromCurrency = function() {
+    return 0;
+};

--- a/src/String.js
+++ b/src/String.js
@@ -143,7 +143,8 @@ String.prototype.toCurrency = function() {
  * number
  * 
  * @param {void}
- * @return {Number} 
+ * @return {Number} returns a number representing the number
+ * form of it calling string.
  */
 String.prototype.fromCurrency = function() {
     return Number(this.replace(/,/g, ''));


### PR DESCRIPTION
## What does this PR do?

Adds `fromCurrency()` to the String prototype object. `fromCurrency()` takes a currency formatted string and returns it as a number.
## Action Points
- Add test to check `fromCurrency()` return type.
- Add test to check `fromCurrency()` returns correct number.
- Implement `fromCurrency()` to pass above tests.
