### PR TITLE
Add getMiddle() function

### DIFF
--- a/spec/string_spec.js
+++ b/spec/string_spec.js
@@ -149,7 +149,7 @@ describe('alternatingCase()', function() {
 });
 
 describe('getMiddle()', function() {
-    it('shouldreturn a string', function() {
+    it('should return a string', function() {
         expect('read'.getMiddle()).toEqual(jasmine.any(String));
     });
 
@@ -157,5 +157,5 @@ describe('getMiddle()', function() {
         expect('read'.getMiddle()).toBe('ea');
         expect('rap'.getMiddle()).toBe('a');
         expect('hendricks'.getMiddle()).toBe('r');
-    })
+    });
 });

--- a/spec/string_spec.js
+++ b/spec/string_spec.js
@@ -147,3 +147,15 @@ describe('alternatingCase()', function() {
         expect('Onomatopoeia'.alternatingCase()).toBe('oNoMaToPoEiA');
     });
 });
+
+describe('getMiddle()', function() {
+    it('shouldreturn a string', function() {
+        expect('read'.getMiddle()).toEqual(jasmine.any(String));
+    });
+
+    it('should return middle of the word', function() {
+        expect('read'.getMiddle()).toBe('ea');
+        expect('rap'.getMiddle()).toBe('a');
+        expect('hendricks'.getMiddle()).toBe('r');
+    })
+});

--- a/src/String.js
+++ b/src/String.js
@@ -192,3 +192,22 @@ String.prototype.alternatingCase = function() {
         }
     });
 };
+
+/**
+ * Get Middle
+ * 
+ * getMiddle gets its calling string. It returns the 2 middle
+ * characters if the string's length is even
+ * 
+ * @param {void}
+ * @return {String} returns the middle word(s) of the string
+ */
+String.prototype.getMiddle = function() {
+    var value = this. split('');
+
+    var half = value.length / 2;
+    if (value.length % 2 === 0) {
+        return value.slice(half-1, half+1).join('');
+    }
+    return value[parseInt(half)];
+};


### PR DESCRIPTION
## What does this PR do?

Adds `getMiddle()` function to the String prototype object. `getMiddle()` returns the middle character of its calling string or the two middle characters if the calling string's length is even.
## Action Points
- Add test to check `getMiddle()` return type.
- Add test to check `getMiddle()` returns the middle characters.
- Implement `getMiddle()` to pass above tests.
